### PR TITLE
fix: Fixed get item by column value query

### DIFF
--- a/monday/client.py
+++ b/monday/client.py
@@ -75,21 +75,35 @@ class Client(object):
         return self.post(json=body)
 
 
-    def get_items_by_column_values(self, board_id, column_id, value, limit: int = 50, state: str = "active"):
+    def get_items_by_column_values(self, board_id, column_id, value, limit: int = 500, state: str = "active"):
         """
-        Default limit is 50.
-        The item's state: all, active, archived, or deleted. The default state is active.
+            Default limit is 500.
+            State is deprecated.
         """
+
         query = f"""
             query {{
-                items_by_column_values (
-                    board_id: {board_id},
+              items_page_by_column_values (
+                limit: {limit},
+                board_id: {board_id},
+                columns: [
+                  {{
                     column_id: "{column_id}",
-                    column_value: "{value}",
-                    limit: {limit},
-                    state: {state}
-                ) {{ id name created_at column_values {{title text}} }}}}
-            """
+                    column_values: ["{value}"]
+                  }}
+                ]) {{
+                    items {{
+                      id
+                      name
+                      created_at
+                      column_values {{
+                        id
+                        text
+                      }}
+                    }}
+                }}
+            }} 
+        """
         body = {"query": query}
         return self.post(json=body)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monday-python"
-version = "0.2.0"
+version = "0.2.1"
 description = "API wrapper for monday.com written in Python"
 authors = ["Gearplug Team <apps@gearplug.io>"]
 license = "MIT"


### PR DESCRIPTION
Changes `get_items_by_column_values` query as Monday API graphql changed.

Release notes: https://developer.monday.com/api-reference/docs/migrating-to-v-2023-10
New query docs: https://developer.monday.com/api-reference/reference/items-page-by-column-values 