### PR TITLE
fix: Fixed update_item query

### DIFF
--- a/monday/client.py
+++ b/monday/client.py
@@ -114,7 +114,7 @@ class Client(object):
             {"column_id": "column_value", "column_id": "column_value"}
         """
         query = """
-            mutation ($boardId: Int!, $itemId: Int!, $columnVals: JSON!) {
+            mutation ($boardId: ID!, $itemId: ID!, $columnVals: JSON!) {
                 change_multiple_column_values (item_id: $itemId, board_id: $boardId, column_values: $columnVals) 
                     { id }
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monday-python"
-version = "0.2.2"
+version = "0.2.1"
 description = "API wrapper for monday.com written in Python"
 authors = ["Gearplug Team <apps@gearplug.io>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monday-python"
-version = "0.2.0"
+version = "0.2.2"
 description = "API wrapper for monday.com written in Python"
 authors = ["Gearplug Team <apps@gearplug.io>"]
 license = "MIT"


### PR DESCRIPTION
`update_item` client method was using an outdated typing for the arguments. Changed `Int!` for `ID!`.