### PR TITLE
fix: Update $boardId type

### DIFF
--- a/monday/client.py
+++ b/monday/client.py
@@ -113,7 +113,7 @@ class Client(object):
         column_values is a dictionary with the following structure:
             {"column_id": "column_value", "column_id": "column_value"}
         """
-        query = "mutation ($boardId: Int!, $myItemName: String!, $columnVals: JSON!) { create_item (board_id: $boardId, item_name: $myItemName, column_values:$columnVals) { id } }"
+        query = "mutation ($boardId: ID!, $myItemName: String!, $columnVals: JSON!) { create_item (board_id: $boardId, item_name: $myItemName, column_values:$columnVals) { id } }"
         variables = {
             "boardId": int(board_id),
             "myItemName": item_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monday-python"
-version = "0.2.2"
+version = "0.2.3"
 description = "API wrapper for monday.com written in Python"
 authors = ["Gearplug Team <apps@gearplug.io>"]
 license = "MIT"


### PR DESCRIPTION
Changed `$boardId` from Int to ID as required in the latest Monday API changes.